### PR TITLE
MAINT: update readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,7 @@ build:
 
 sphinx:
   builder: html
+  configuration: book/conf.py
   fail_on_warning: false
 
 # As of 4 Sept 2024, this was taking too long to build. Turning off until we


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/